### PR TITLE
Create python-publish.yml

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,45 @@
+name: reusable_publish_to_pypi
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: 'Stringified JSON object listing target Python versions'
+        required: true
+        type: string
+    secrets:
+      TEST_PYPI_API_TOKEN:
+        required: true
+      PYPI_API_TOKEN:
+        required: true
+        
+
+jobs:
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ${{ fromJson(inputs.python_version) }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build --sdist --wheel --outdir dist/
+    - name: Publish package to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+name: Publish Python package
+
+on:
+  push:
+  release:
+    types: [published]
+
+env:
+  python_versions: 
+jobs:
+
+  run-pytest:
+    # FIXME: This part will have to be updated whenever github allows
+    # for dynamic name resolution at both repo (Rodrigo-Tenorio/distromax)
+    # and refenrec (master) level.
+    uses: Rodrigo-Tenorio/distromax/.github/workflows/run-pytest.yml@master
+    with:
+      python_version: "[\"3.8\", \"3.9\"]"
+
+
+  publish-pypi:
+    # FIXME: This part will have to be updated whenever github allows
+    # for dynamic name resolution at both repo (Rodrigo-Tenorio/distromax)
+    # and refenrec (master) level.
+    needs: run-pytest
+    uses: Rodrigo-Tenorio/distromax/.github/workflows/publish-pypi.yml@master
+    with:
+      python_version: "[\"3.9\"]"
+    secrets:
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,0 +1,33 @@
+name: reusable_pytest_workflow
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: 'Stringified JSON object listing target Python versions'
+        required: true
+        type: string
+
+jobs:
+  pytest:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ${{ fromJson(inputs.python_version) }}
+
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install .[examples]
+    - name: Test with pytest
+      run: |
+        pytest $GITHUB_WORKSPACE/tests/test.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,34 +1,15 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
-name: pytest
+name: integration_tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9"]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
-        python -m pip install .[examples]
-    - name: Test with pytest
-      run: |
-        pytest $GITHUB_WORKSPACE/tests/test.py
+  run-pytest:
+    # FIXME: This part will have to be updated whenever github allows
+    # for dynamic name resolution at both repo (Rodrigo-Tenorio/distromax)
+    # and refenrec (master) level.
+    uses: Rodrigo-Tenorio/distromax/.github/workflows/run-pytest.yml@master
+    with:
+      python_version: "[\"3.8\", \"3.9\"]"


### PR DESCRIPTION
Missing things:

- [x] Check whether github secrets must be explicitly passed to reusable workflows.
- [x] Add actual publishing to pypi.