### PR TITLE
Run tests workflow on multiple platforms

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,13 +6,19 @@ on:
 
 jobs:
   pytest:
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
 
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os:
+          - macOS
+          - Ubuntu
+          - Windows
         python-version:
           - 3.8
           - 3.9
+    runs-on: ${{ matrix.os }}-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR closes #11 by reconfiguring the GHA 'tests' workflow to run on multiple platforms.