### PR TITLE
Declare tag_prefix for versioneer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ VCS = git
 style = pep440
 versionfile_source = distromax/_version.py
 versionfile_build = distromax/_version.py
-tag_prefix =
+tag_prefix = v


### PR DESCRIPTION
This PR closes #14 by properly declaring the `tag_prefix` in the versioneer config.