### PR TITLE
Parametrize example tests

### DIFF
--- a/tests/test_distromax.py
+++ b/tests/test_distromax.py
@@ -1,7 +1,6 @@
 import glob
 import logging
 import os
-import subprocess
 import sys
 from pathlib import Path
 
@@ -70,7 +69,10 @@ def test_BatchMaxGumbelNotchingOutliers():
     [pytest.param(ex, id=ex.name) for ex in EXAMPLES]
 )
 def test_Examples(example):
-    subprocess.run([sys.executable, "-s", str(example)])
+    # read the example script
+    code = compile(example.read_text(), str(example), "exec")
+    # run it using this Python process
+    exec(code, globals())
 
 
 if __name__ == "__main__":

--- a/tests/test_distromax.py
+++ b/tests/test_distromax.py
@@ -3,6 +3,7 @@ import logging
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import numpy as np
 from scipy import stats
@@ -10,6 +11,9 @@ from scipy import stats
 import distromax
 
 import pytest
+
+HERE = Path(__file__).parent
+EXAMPLES = (HERE.parent / "examples").glob("*.py")
 
 ground_truth_gumbel = stats.gumbel_r(1, 1)
 
@@ -61,13 +65,12 @@ def test_BatchMaxGumbelNotchingOutliers():
     test_BatchMaxGumbel(fitting_class=fitting_class, fitting_class_kwargs=fitting_class_kwargs)
 
 
-def test_Examples():
-    # Basic test to check nothing is not broken
-    examples_folder = os.path.join(sys.path[0], "../examples/*.py")
-    logging.info(f"Example's pattern: {examples_folder}")
-    for example in glob.glob(examples_folder):
-        logging.info(f"Running example {os.path.basename(example)}")
-        subprocess.run(["python", "-s", example])
+@pytest.mark.parametrize(
+    "example",
+    [pytest.param(ex, id=ex.name) for ex in EXAMPLES]
+)
+def test_Examples(example):
+    subprocess.run([sys.executable, "-s", str(example)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR closes #13 by updating the `test_distromax.py` module to use `pytest.mark.parametrize` to run each example as an independent test.

I also reworked the example test execution to read the example script and run it as part of the same Python process, which should make it marginally more efficient, but should otherwise not change anything.