### PR TITLE
Automatically cancel redundant integration test workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     name: Python ${{ matrix.python-version }} (${{ matrix.os }})


### PR DESCRIPTION
This PR adds configuration for the `tests` GHA workflow to automatically cancel when a newer workflow is triggered for the same ref (e.g. pull request), this might cut down on wait times now that the workflow has a lot of jobs.